### PR TITLE
Remove Markdown URLs

### DIFF
--- a/utils/common.py
+++ b/utils/common.py
@@ -76,8 +76,11 @@ def sanitize_text(text: str) -> str:
 
     # remove any urls from the text
     regex_urls = r"((http|https)\:\/\/)?[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*"
-
     result = re.sub(regex_urls, " ", text)
+
+    # remove markdown url
+    pattern = r'\[([^]]*)\]\(([^)]*)\)'
+    result = re.sub(pattern, " ", result)
 
     # note: not removing apostrophes
     regex_expr = r"\s['|’]|['|’]\s|[\^_~@!&;#:\-–—%“”‘\"%\*/{}\[\]\(\)\\|<>=+]"


### PR DESCRIPTION
Fixes #66 where video was failing to generate due to a there being a markdown url in the selftext. This PR sanitizes the comment to remove markdown URL's