### PR TITLE
restore settings and save error.png beside screenshots

### DIFF
--- a/comments/screenshot.py
+++ b/comments/screenshot.py
@@ -357,9 +357,10 @@ def download_screenshots_of_reddit_posts(
                             
             except Exception as e:
                 print(f"Error: {e}")
-                print("Taking screenshot and re-throw...")
-                page.screenshot(path='error.png')
-                print("See 'error.png'")
+                print("Taking screenshot and re-throwing Exception...")
+                error_path = Path(f"{video_directory}/error.png")
+                page.screenshot(path=error_path)
+                print(f"See '{error_path}'")
                 raise
 
             print("Screenshots downloaded Successfully.")

--- a/config/settings.py
+++ b/config/settings.py
@@ -4,20 +4,19 @@ from pathlib import Path
 
 subreddits = [
     "askreddit",
-    # "movies",
-    # "AmItheAsshole",
-    # "antiwork",
-    # "AskMen",
-    # "ChoosingBeggars",
-    # "hatemyjob",
-    # "NoStupidQuestions",
-    # "pettyrevenge",
-    # "Showerthoughts",
-    # "TooAfraidToAsk",
-    # "TwoXChromosomes",
-    # "unpopularopinion",
-    # "confessions",
-    # "confession",
+    "AmItheAsshole",
+    "antiwork",
+    "AskMen",
+    "ChoosingBeggars",
+    "hatemyjob",
+    "NoStupidQuestions",
+    "pettyrevenge",
+    "Showerthoughts",
+    "TooAfraidToAsk",
+    "TwoXChromosomes",
+    "unpopularopinion",
+    "confessions",
+    "confession",
 ]
 
 subreddits_excluded = [
@@ -61,7 +60,7 @@ reddit_comment_width = 0.95
 comment_length_max = 600
 comment_limit = 100
 comment_screenshot_timeout = 30000
-screenshot_debug = True  # if True enables breakpoints in critical parts of screenshot.py
+screenshot_debug = False  # if True enables breakpoints in critical parts of screenshot.py
 
 # Video settings
 background_colour = [26, 26, 27]
@@ -71,12 +70,12 @@ background_volume = 0.5
 commentstyle = "reddit"
 enable_background = False
 enable_comments = True
-enable_compilation = True # True -> compile video
+enable_compilation = True  # True -> compile video
 enable_nsfw_content = False
 enable_overlay = False
-enable_selftext = False
-enable_comments_audio = False # True -> generate mp3 from comment text
-enable_thumbnails = False # True -> generate post thumbnails
+enable_selftext = True
+enable_comments_audio = True  # True -> generate mp3 from comment text
+enable_thumbnails = True  # True -> generate post thumbnails
 enable_upload = False
 enable_screenshot_title_image = False
 enable_reddit_mentions = False


### PR DESCRIPTION
Restore settings to previous values (and disable screenshot_debug), and save error.png in the same folder of the screenshots.