### PR TITLE
Use old reddit

### DIFF
--- a/comments/screenshot.py
+++ b/comments/screenshot.py
@@ -207,8 +207,6 @@ def download_screenshots_of_reddit_posts(
             )
         else:
             
-            # breakpoint()
-            
             use_permalinks = settings.use_comments_permalinks
             
             def get_comment_excerpt(comment):
@@ -244,7 +242,6 @@ def download_screenshots_of_reddit_posts(
                         off_page_comments.append(comment)
                 print(f"ON PAGE: {len(on_page_comments)}  OFF PAGE: {len(off_page_comments)}")
                 print()
-                # breakpoint()
             
             try:
             
@@ -283,7 +280,7 @@ def download_screenshots_of_reddit_posts(
                                     print(f"Comment not found on page, using permalink to '{comment.permalink}'...")
                                     print("Use permalinks from now on...")
                                     use_permalinks = True
-                                # breakpoint()
+
                                 page.goto(f"{reddit_base_url}{comment.permalink}", timeout=0)
 
                             # Bypass "See this post in..."

--- a/comments/screenshot.py
+++ b/comments/screenshot.py
@@ -357,9 +357,10 @@ def download_screenshots_of_reddit_posts(
                             
             except Exception as e:
                 print(f"Error: {e}")
-                print("Taking screenshot and re-throw...")
-                page.screenshot(path='error.png')
-                print("See 'error.png'")
+                print("Taking screenshot and re-throwing Exception...")
+                error_path = Path(f"{video_directory}/error.png")
+                page.screenshot(path=error_path)
+                print(f"See '{error_path}'")
                 raise
 
             print("Screenshots downloaded Successfully.")

--- a/comments/screenshot.py
+++ b/comments/screenshot.py
@@ -224,26 +224,26 @@ def download_screenshots_of_reddit_posts(
                 
                 return selector
 
-            def print_comments_availability_on_page(comments):
+            def print_comments_availability_on_page(comments, detailed=False):
                 print()
                 print("COMMENTS AVAILABILITY ON PAGE")
                 on_page_comments = []
                 off_page_comments = []
                 for (_idx, comment) in enumerate(comments):
                     comment_excerpt = get_comment_excerpt(comment)
-                    print(f" [{_idx + 1}/{len(accepted_comments)} {comment.id}] {comment.author}: {comment_excerpt}")
+                    if detailed: print(f" [{_idx + 1}/{len(accepted_comments)} {comment.id}] {comment.author}: {comment_excerpt}")
                     
                     # Locate comment
                     selector = get_comment_selector(comment)
                     comment_loc = page.locator(selector).first
                     
                     if comment_loc.is_visible():
-                        print("  ON PAGE")
+                        if detailed: print("  ON PAGE")
                         on_page_comments.append(comment)
                     else:
-                        print(" OFF PAGE")
+                        if detailed: print(" OFF PAGE")
                         off_page_comments.append(comment)
-                print(f"ON PAGE: {len(on_page_comments)}  OFF PAGE: {len(off_page_comments)}")
+                print(f"ON PAGE: {len(on_page_comments)} | OFF PAGE: {len(off_page_comments)} | TOTAL: {len(comments)}")
                 print()
             
             try:

--- a/comments/screenshot.py
+++ b/comments/screenshot.py
@@ -57,7 +57,7 @@ def download_screenshots_of_reddit_posts(
         url: URL of the Reddit content to be screenshotted.
         video_directory: Path where the screenshots will be saved.
     """
-    print("Downloading screenshots of reddit posts...")
+    # print("Downloading screenshots of reddit posts...")
     # id = re.sub(r"[^\w\s-]", "", reddit_object.meta.id)
     # # ! Make sure the reddit screenshots folder exists
     # title_path = safe_filename(reddit_object.title)
@@ -83,6 +83,7 @@ def download_screenshots_of_reddit_posts(
         # Get the thread screenshot
         page = context.new_page()
 
+        print("Trying to login...")
         page.goto("https://www.reddit.com/login")
 
         #time.sleep(5)
@@ -182,6 +183,8 @@ def download_screenshots_of_reddit_posts(
             is_dark_mode_enabled = dark_mode_setter_loc.get_attribute('enabled') is not None
             if (settings.theme == "dark" and not is_dark_mode_enabled) or (settings.theme != "dark" and is_dark_mode_enabled):
                 dark_mode_tracker_loc.dispatch_event('click')
+        
+        print("Downloading screenshots of reddit posts...")
         
         # page.set_viewport_size(ViewportSize(width=1920, height=1080))
         page.set_viewport_size(ViewportSize(width=1200, height=700))
@@ -376,7 +379,6 @@ def download_screenshots_of_reddit_posts(
                             
             except Exception as e:
                 print(f"Error: {e}")
-                print(f"Error is None: {e is None}  Error str: '{e}'")
                 print("Taking screenshot and re-throwing Exception...")
                 error_path = Path(f"{video_directory}/error.png")
                 page.screenshot(path=error_path)

--- a/comments/screenshot.py
+++ b/comments/screenshot.py
@@ -341,7 +341,7 @@ def download_screenshots_of_reddit_posts(
                                         if (commentBody) commentBody.style.backgroundColor = 'inherit';
                                     }""")
 
-                                entry_element.scroll_into_view_if_needed()
+                                if settings.screenshot_debug: entry_element.scroll_into_view_if_needed()
                                 entry_element.screenshot(path=comment_path)
                             else:
                                 print("Mmmmhhh... could not create screenshot!")

--- a/comments/screenshot.py
+++ b/comments/screenshot.py
@@ -186,8 +186,8 @@ def download_screenshots_of_reddit_posts(
         
         print("Downloading screenshots of reddit posts...")
         
-        # page.set_viewport_size(ViewportSize(width=1920, height=1080))
-        page.set_viewport_size(ViewportSize(width=1200, height=700))
+        page.set_viewport_size(ViewportSize(width=1920, height=1080))
+        # page.set_viewport_size(ViewportSize(width=1200, height=700))
 
         if page.locator('[data-testid="content-gate"]').is_visible():
             # This means the post is NSFW and requires to click the proceed button.

--- a/config/settings.py
+++ b/config/settings.py
@@ -4,20 +4,19 @@ from pathlib import Path
 
 subreddits = [
     "askreddit",
-    # "movies",
-    # "AmItheAsshole",
-    # "antiwork",
-    # "AskMen",
-    # "ChoosingBeggars",
-    # "hatemyjob",
-    # "NoStupidQuestions",
-    # "pettyrevenge",
-    # "Showerthoughts",
-    # "TooAfraidToAsk",
-    # "TwoXChromosomes",
-    # "unpopularopinion",
-    # "confessions",
-    # "confession",
+    "AmItheAsshole",
+    "antiwork",
+    "AskMen",
+    "ChoosingBeggars",
+    "hatemyjob",
+    "NoStupidQuestions",
+    "pettyrevenge",
+    "Showerthoughts",
+    "TooAfraidToAsk",
+    "TwoXChromosomes",
+    "unpopularopinion",
+    "confessions",
+    "confession",
 ]
 
 subreddits_excluded = [
@@ -61,7 +60,7 @@ reddit_comment_width = 0.95
 comment_length_max = 600
 comment_limit = 100
 comment_screenshot_timeout = 30000
-screenshot_debug = True  # if True enables breakpoints in critical parts of screenshot.py
+screenshot_debug = False  # if True enables breakpoints in critical parts of screenshot.py
 
 # Video settings
 background_colour = [26, 26, 27]
@@ -71,12 +70,12 @@ background_volume = 0.5
 commentstyle = "reddit"
 enable_background = False
 enable_comments = True
-enable_compilation = True # True -> compile video
+enable_compilation = True  # True -> compile video
 enable_nsfw_content = False
 enable_overlay = False
-enable_selftext = False
-enable_comments_audio = False # True -> generate mp3 from comment text
-enable_thumbnails = False # True -> generate post thumbnails
+enable_selftext = True
+enable_comments_audio = True  # True -> generate mp3 from comment text
+enable_thumbnails = True  # True -> generate post thumbnails
 enable_upload = False
 enable_screenshot_title_image = False
 enable_reddit_mentions = False

--- a/config/settings.py
+++ b/config/settings.py
@@ -4,19 +4,19 @@ from pathlib import Path
 
 subreddits = [
     "askreddit",
-    "AmItheAsshole",
-    "antiwork",
-    "AskMen",
-    "ChoosingBeggars",
-    "hatemyjob",
-    "NoStupidQuestions",
-    "pettyrevenge",
-    "Showerthoughts",
-    "TooAfraidToAsk",
-    "TwoXChromosomes",
-    "unpopularopinion",
-    "confessions",
-    "confession",
+    # "AmItheAsshole",
+    # "antiwork",
+    # "AskMen",
+    # "ChoosingBeggars",
+    # "hatemyjob",
+    # "NoStupidQuestions",
+    # "pettyrevenge",
+    # "Showerthoughts",
+    # "TooAfraidToAsk",
+    # "TwoXChromosomes",
+    # "unpopularopinion",
+    # "confessions",
+    # "confession",
 ]
 
 subreddits_excluded = [
@@ -60,7 +60,9 @@ reddit_comment_width = 0.95
 comment_length_max = 600
 comment_limit = 100
 comment_screenshot_timeout = 30000
-screenshot_debug = False  # if True enables breakpoints in critical parts of screenshot.py
+screenshot_debug = True  # if True enables breakpoints in critical parts of screenshot.py
+use_old_reddit = True  # if True use old.reddit.com instead of reddit.com
+use_comments_permalinks = False  # if True don't try to scrape subreddit page, use comment permalinks directly
 
 # Video settings
 background_colour = [26, 26, 27]
@@ -70,12 +72,12 @@ background_volume = 0.5
 commentstyle = "reddit"
 enable_background = False
 enable_comments = True
-enable_compilation = True  # True -> compile video
+enable_compilation = True  # if True compile video
 enable_nsfw_content = False
 enable_overlay = False
-enable_selftext = True
-enable_comments_audio = True  # True -> generate mp3 from comment text
-enable_thumbnails = True  # True -> generate post thumbnails
+enable_selftext = False
+enable_comments_audio = False  # if True generate mp3 from comment text
+enable_thumbnails = False  # if True generate post thumbnails
 enable_upload = False
 enable_screenshot_title_image = False
 enable_reddit_mentions = False
@@ -150,7 +152,7 @@ newcaster_size = (video_width * 0.5, video_height * 0.5)
 threads = 4
 
 # Whether to launch the Browser in Headless mode
-headless_browser = True  # defaults to True, but can set it to False to see what happens
+headless_browser = False  # defaults to True, but can set it to False to see what happens
 
 if platform == "linux" or platform == "linux2":
     firefox_binary = "/opt/firefox/firefox"

--- a/config/settings.py
+++ b/config/settings.py
@@ -62,7 +62,7 @@ comment_limit = 100
 comment_screenshot_timeout = 30000
 screenshot_debug = True  # if True enables breakpoints in critical parts of screenshot.py
 use_old_reddit = True  # if True use old.reddit.com instead of reddit.com
-use_comments_permalinks = False  # if True don't try to scrape subreddit page, use comment permalinks directly
+use_comments_permalinks = True  # if True don't try to scrape subreddit page, use comment permalinks directly
 
 # Video settings
 background_colour = [26, 26, 27]

--- a/video_generation/video.py
+++ b/video_generation/video.py
@@ -497,9 +497,10 @@ def create(video_directory: Path, post: Submission, thumbnails: List[Path]) -> N
 
         screenshot_directory = Path(settings.screenshot_directory, v.meta.id)
         if settings.commentstyle == "reddit":
+            reddit_base_url = "http://old.reddit.com" if settings.use_old_reddit else "https://reddit.com"
             download_screenshots_of_reddit_posts(
                 accepted_comments,
-                f"http://reddit.com{v.meta.permalink}",
+                f"{reddit_base_url}{v.meta.permalink}",
                 screenshot_directory,
             )
 


### PR DESCRIPTION
This PR attempts to use `old.reddit.com` instead of `reddit.com` to take screenshots (configurable in `settings.py`), and also adds a `use_comments_permalinks` setting...

 - save error.png in video directory (also in the other PR)
 - use old.reddit.com for screenshots  if settings.use_old_reddit is True
 - use permalink if settings.use_comments_permalink is True
 - minor function refactors
 - remove unneeded breakpoints
 - update log order of "Downloading screenshots..." and "Launching Browser"
 - some other things I might be missing ;P

Next step would be to add a login via old.reddit.com directly (as it seems to always go through from some experiments 😉), and refactor things a bit.

... and also restore settings!


