### PR TITLE
[template] adjust padding of #comment-container

### DIFF
--- a/comment_templates/dark_reddit_mockup/index.html
+++ b/comment_templates/dark_reddit_mockup/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=1024">
     <style type="text/css">
       #comment-container {
-        padding: 8px;
+        padding-top: 8px;
+        padding-bottom: 8px;
         max-width: 750px;
       }
     

--- a/comment_templates/light_reddit_mockup/index.html
+++ b/comment_templates/light_reddit_mockup/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=1024">
     <style type="text/css">
       #comment-container {
-        padding: 8px;
+        padding-top: 8px;
+        padding-bottom: 8px;
         max-width: 750px;
       }
     

--- a/comment_templates/old_reddit_mockup/index.html
+++ b/comment_templates/old_reddit_mockup/index.html
@@ -7,6 +7,8 @@
     <style type="text/css">
       /* Custom css */
       #comment-container {
+         padding-top: 8px;
+         padding-bottom: 8px;
          max-width: 750px;
       }
       


### PR DESCRIPTION
[template] adjust padding of #comment-container...

Only for templates: add padding only on top/bottom, 0 to left/right.

Ex.:
![image](https://github.com/alexlaverty/python-reddit-youtube-bot/assets/1266447/aa7d8019-33fe-4dbf-8551-a78d61939321)

